### PR TITLE
Update usage of lxml to support current version.

### DIFF
--- a/src/shared/Parser.py
+++ b/src/shared/Parser.py
@@ -1,4 +1,5 @@
-import lxml
+from lxml import etree
+from io import StringIO
 from decimal import Decimal
 
 class XPath:
@@ -47,7 +48,7 @@ class parser:
         app_data = dict()
 
         # Loading Html
-        html_map = lxml.html.fromstring(html)
+        html_map = etree.parse(StringIO(html), etree.HTMLParser())
 
         # Reaching Useful Data
         app_data['Name'] = self.extract_node_text(html_map, 'Name')
@@ -117,7 +118,7 @@ class parser:
 
     def parse_related_apps(self, html):
         # Loading Html
-        html_map = lxml.html.fromstring(html)
+        html_map = etree.parse(StringIO(html), etree.HTMLParser())
 
         # Reaching Useful Data
         xpath = XPath.xPaths['RelatedApps']

--- a/src/shared/Parser.py
+++ b/src/shared/Parser.py
@@ -1,5 +1,4 @@
-from lxml import etree
-from io import StringIO
+import lxml.html
 from decimal import Decimal
 
 class XPath:
@@ -48,7 +47,7 @@ class parser:
         app_data = dict()
 
         # Loading Html
-        html_map = etree.parse(StringIO(html), etree.HTMLParser())
+        html_map = lxml.html.fromstring(html)
 
         # Reaching Useful Data
         app_data['Name'] = self.extract_node_text(html_map, 'Name')
@@ -118,7 +117,7 @@ class parser:
 
     def parse_related_apps(self, html):
         # Loading Html
-        html_map = etree.parse(StringIO(html), etree.HTMLParser())
+        html_map = lxml.html.fromstring(html)
 
         # Reaching Useful Data
         xpath = XPath.xPaths['RelatedApps']


### PR DESCRIPTION
Calls to lxml.html.fromstring( ) were failing with lxml 3.6.4 because the html module was not brought into the lxml namespace as part of the lxml import.